### PR TITLE
Revert "Issue: wrong pathname encoding (#390)"

### DIFF
--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -15,14 +15,9 @@ let getLocation = source => {
     const url = new URL(href);
     pathname = url.pathname;
   }
-  
-  const encodedPathname = pathname
-  .split("/")
-  .map(pathPart => encodeURIComponent(decodeURIComponent(pathPart)))
-  .join("/");
 
   return {
-    pathname: encodedPathname,
+    pathname: encodeURI(decodeURI(pathname)),
     search,
     hash,
     href,

--- a/src/lib/history.test.js
+++ b/src/lib/history.test.js
@@ -57,22 +57,6 @@ describe("createHistory", () => {
 
     expect(history.location.pathname).toEqual("/p%C3%A5ge");
   });
-  
-  it("should not encode location pathname if it is already encoded", () => {
-    const mockSource = {
-      history: {},
-      location: {
-        pathname: "/%2F",
-        search: "",
-        hash: ""
-      }
-    };
-
-    const history = createHistory(mockSource);
-
-    expect(history.location.pathname).toEqual("/%2F");
-  });
-  
 });
 
 describe("navigate", () => {


### PR DESCRIPTION
This reverts commit e203fe612236851a0bd3c77dba693e539a351c62.

This commit cause issues. For some context - this change was merged/pushed in `@reach/router` repo, but was never published. We did publish it in our fork as we used `master` branch for it.

Issues happens for us when page's path contain characters like `@`. After adjusting our code in https://github.com/gatsbyjs/gatsby/blob/7193303a4adb7c1a880d6f0580780dc75e407c32/packages/gatsby/cache-dir/root.js#L50-L53 and https://github.com/gatsbyjs/gatsby/blob/7193303a4adb7c1a880d6f0580780dc75e407c32/packages/gatsby/cache-dir/production-app.js#L110-L113 to use change that I'm reverting ( https://github.com/gatsbyjs/gatsby/commit/70cf6bbaa74e5f78e6f8100d735f80b2e168e4c2 ), we saw some problems with client-side-routes (see failing e2e dev and prod runtime tests on that commit).

Ref https://github.com/gatsbyjs/gatsby/pull/29935

I released this change as canary to npm and tested with https://github.com/gatsbyjs/gatsby/pull/29935/commits/a9f0814f59949e6920e79b741383e71e449f98d5 which passes all our existing tests and test scenario I added for page path containing `@`