### PR TITLE
Update repository links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/reach/router.git"
+    "url": "git+https://github.com/gatsbyjs/reach-router.git"
   },
   "keywords": [
     "react",
@@ -85,7 +85,7 @@
     "react-lifecycles-compat": "^3.0.4"
   },
   "bugs": {
-    "url": "https://github.com/reach/router/issues"
+    "url": "https://github.com/gatsbyjs/reach-router/issues"
   },
-  "homepage": "https://github.com/reach/router#readme"
+  "homepage": "https://github.com/gatsbyjs/reach-router#readme"
 }


### PR DESCRIPTION
The repository [listed on NPM for `@gatsbyjs/reach-router`](https://www.npmjs.com/package/@gatsbyjs/reach-router) is https://github.com/reach/router, which is incorrect. This pull request addresses the issue by updating the value of `homepage`, `bugs.url` and `repository.url` in `package.json`.

<img width="427" alt="image" src="https://user-images.githubusercontent.com/541045/175914001-ff2a8388-4f3e-4213-b8d4-140883c2ef6d.png">
