### PR TITLE
Export match util

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export {
   startsWith,
   pick,
   resolve,
-  match as matchPath,
+  match,
   insertParams,
   validateRedirect,
   shallowCompare,


### PR DESCRIPTION
In v1 the named `match` export was only available via `@gatsbyjs/reach-router/lib/utils`, which no longer exists in our current build output files in v2.

We should export it from index and remove the extra renamed `matchPath` export.